### PR TITLE
fix org.apache.hadoop.conf.Configuration cannot set in the class

### DIFF
--- a/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordInputFormat.java
+++ b/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordInputFormat.java
@@ -42,6 +42,7 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 	private String[] paths;
 	private transient TFRecordReader tfRecordReader;
 	private transient FSDataInputStream fsdis;
+	private transient org.apache.hadoop.conf.Configuration hadoopConfiguration;
 	private boolean end = false;
 	private static Logger LOG = LoggerFactory.getLogger(TFRecordInputFormat.class);
 
@@ -57,6 +58,10 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 	@Override
 	public void configure(Configuration configuration) {
 
+	}
+
+	public void setHadoopConfiguration(org.apache.hadoop.conf.Configuration configuration) {
+		this.hadoopConfiguration = configuration;
 	}
 
 	@Override
@@ -108,8 +113,13 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 	public void open(TFRecordInputSplit split) throws IOException {
 		final Path file = split.getPath();
 		LOG.info("open split path: " + file.toString());
-		org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();
-		FileSystem fs = file.getFileSystem(configuration);
+		FileSystem fs = null;
+		if (null != hadoopConfiguration) {
+			fs = file.getFileSystem(hadoopConfiguration);
+		} else {
+			org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();
+			fs = file.getFileSystem(configuration);
+		}
 		fsdis = fs.open(file, 4 * 1024 * 1024);
 		tfRecordReader = new TFRecordReader(fsdis, true);
 	}

--- a/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordSource.java
+++ b/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordSource.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * flink source: read tensorflow TFRecord format file, output TFRecord byte array.
@@ -32,6 +33,7 @@ public class TFRecordSource extends InputFormatSourceFunction<byte[]> implements
 	public TFRecordSource(InputFormat<byte[], ?> format, TypeInformation<byte[]> typeInfo) {
 		super(format, typeInfo);
 	}
+	public static TFRecordInputFormat inputFormat = null;
 
 	@Override
 	public TypeInformation getProducedType() {
@@ -39,7 +41,13 @@ public class TFRecordSource extends InputFormatSourceFunction<byte[]> implements
 	}
 
 	public static TFRecordSource createSource(String[] paths, int epochs) {
-		TFRecordInputFormat inputFormat = new TFRecordInputFormat(paths, epochs);
+		inputFormat = new TFRecordInputFormat(paths, epochs);
 		return new TFRecordSource(inputFormat, TypeInformation.of(byte[].class));
+	}
+
+	public static void setHadoopConfiguration(Configuration configuration) {
+		if (null != inputFormat && null != configuration) {
+			inputFormat.setHadoopConfiguration(configuration);
+		}
 	}
 }


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*(For example: This pull request makes user can stop workflow externally.)*


## Brief change log

*(for example:)*
  - *Send StopDagEvent to Airflow scheduler via notification service*
  - *Once received StopDagEvent, Airflow scheduler kills all running dag runs*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests.