### PR TITLE
fix org.apache.hadoop.conf.Configuration cannot set in the class

### DIFF
--- a/flink-ml-examples/pom.xml
+++ b/flink-ml-examples/pom.xml
@@ -58,6 +58,43 @@
             <artifactId>flink-table-planner_${scala.major.version}</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- for the HDFS mini cluster test suite -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>test</scope>
+            <version>${hadoop.version}</version><!--$NO-MVN-MAN-VER$-->
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>commons-math3</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-ml-examples/src/test/java/org/flinkextended/flink/ml/examples/tensorflow/ut/TFRecordInputFormatTest.java
+++ b/flink-ml-examples/src/test/java/org/flinkextended/flink/ml/examples/tensorflow/ut/TFRecordInputFormatTest.java
@@ -19,6 +19,11 @@
 package org.flinkextended.flink.ml.examples.tensorflow.ut;
 
 
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.flinkextended.flink.ml.examples.tensorflow.mnist.MnistDataUtil;
 import org.flinkextended.flink.ml.tensorflow.io.TFRecordInputFormat;
 import org.flinkextended.flink.ml.tensorflow.io.TFRecordInputSplit;
@@ -32,12 +37,18 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 
 
 public class TFRecordInputFormatTest {
+
+	@ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+
 	@BeforeClass
 	public static void setUp() throws Exception {
 		MnistDataUtil.prepareData();
@@ -70,4 +81,41 @@ public class TFRecordInputFormatTest {
 		flinkEnv.execute();
 	}
 
+
+	@Test
+	public void testReadTFRecordStreamHadoopConfiguration() throws Exception {
+		System.out.println("Run Test: " + SysUtil._FUNC_());
+
+		//create temp hdfs
+		final File baseDir = TEMP_FOLDER.newFolder();
+		final Configuration hdConf = new Configuration();
+		hdConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+		final MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(hdConf);
+		MiniDFSCluster hdfsCluster = builder.build();
+		final org.apache.hadoop.fs.FileSystem hdfs = hdfsCluster.getFileSystem();
+
+		//copy the tfrecord file to hdfs
+		Path basePath = new Path(hdfs.getUri() + "/tests");
+		String rootPath = new File("").getAbsolutePath();
+		String[] paths = new String[2];
+		paths[0] = rootPath + "/target/data/test/0.tfrecords";
+		paths[1] = rootPath + "/target/data/test/1.tfrecords";
+		hdfs.copyFromLocalFile(new org.apache.hadoop.fs.Path(rootPath + "/target/data/test/0.tfrecords"), new org.apache.hadoop.fs.Path(hdfs.getUri() + "/tests/0.tfrecords"));;
+		hdfs.copyFromLocalFile(new org.apache.hadoop.fs.Path(rootPath + "/target/data/test/1.tfrecords"), new org.apache.hadoop.fs.Path(hdfs.getUri() + "/tests/1.tfrecords"));
+
+		//submit flink job local
+		StreamExecutionEnvironment flinkEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		TFRecordSource source = TFRecordSource.createSource(new String[]{hdfs.getUri() + "/tests/0.tfrecords", hdfs.getUri() + "/tests/1.tfrecords"}, 3, hdfsCluster.getConfiguration(0));
+		DataStream<byte[]> input = flinkEnv.addSource(source).setParallelism(2);
+		input.writeUsingOutputFormat(new TraceTFRecordOutputFormat());
+		flinkEnv.execute();
+
+		//destroy mini dfs cluster
+		if (hdfsCluster != null) {
+			hdfsCluster
+					.getFileSystem()
+					.delete(new org.apache.hadoop.fs.Path(basePath.toUri()), true);
+			hdfsCluster.shutdown();
+		}
+	}
 }

--- a/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordInputFormat.java
+++ b/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordInputFormat.java
@@ -42,7 +42,7 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 	private String[] paths;
 	private transient TFRecordReader tfRecordReader;
 	private transient FSDataInputStream fsdis;
-	private transient org.apache.hadoop.conf.Configuration hadoopConfiguration;
+	private static org.apache.hadoop.conf.Configuration hadoopConfiguration;
 	private boolean end = false;
 	private static Logger LOG = LoggerFactory.getLogger(TFRecordInputFormat.class);
 
@@ -55,13 +55,19 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 		LOG.info("input epochs:" + this.epochs);
 	}
 
+	public TFRecordInputFormat(String[] paths, int epochs, org.apache.hadoop.conf.Configuration hadoopConfiguration) {
+		this.paths = paths;
+		this.epochs = epochs;
+		if (epochs <= 0) {
+			this.epochs = Integer.MAX_VALUE;
+		}
+		LOG.info("input epochs:" + this.epochs);
+		this.hadoopConfiguration = hadoopConfiguration;
+	}
+
 	@Override
 	public void configure(Configuration configuration) {
 
-	}
-
-	public void setHadoopConfiguration(org.apache.hadoop.conf.Configuration configuration) {
-		this.hadoopConfiguration = configuration;
 	}
 
 	@Override
@@ -123,7 +129,6 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 		fsdis = fs.open(file, 4 * 1024 * 1024);
 		tfRecordReader = new TFRecordReader(fsdis, true);
 	}
-
 
 	@Override
 	public boolean reachedEnd() throws IOException {

--- a/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordInputFormat.java
+++ b/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordInputFormat.java
@@ -42,6 +42,7 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 	private String[] paths;
 	private transient TFRecordReader tfRecordReader;
 	private transient FSDataInputStream fsdis;
+	private transient org.apache.hadoop.conf.Configuration hadoopConfiguration;
 	private boolean end = false;
 	private static Logger LOG = LoggerFactory.getLogger(TFRecordInputFormat.class);
 
@@ -57,6 +58,10 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 	@Override
 	public void configure(Configuration configuration) {
 
+	}
+
+	public void setHadoopConfiguration(org.apache.hadoop.conf.Configuration configuration) {
+		this.hadoopConfiguration = configuration;
 	}
 
 	@Override
@@ -108,8 +113,13 @@ public class TFRecordInputFormat extends RichInputFormat<byte[], TFRecordInputSp
 	public void open(TFRecordInputSplit split) throws IOException {
 		final Path file = split.getPath();
 		LOG.info("open split path: " + file.toString());
-		org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();
-		FileSystem fs = file.getFileSystem(configuration);
+		FileSystem fs = null;
+		if (null != hadoopConfiguration) {
+			fs = file.getFileSystem(hadoopConfiguration);
+		} else {
+			org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();
+			fs = file.getFileSystem(configuration);
+		}
 		fsdis = fs.open(file, 4 * 1024 * 1024);
 		tfRecordReader = new TFRecordReader(fsdis, true);
 	}

--- a/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordSource.java
+++ b/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordSource.java
@@ -33,7 +33,6 @@ public class TFRecordSource extends InputFormatSourceFunction<byte[]> implements
 	public TFRecordSource(InputFormat<byte[], ?> format, TypeInformation<byte[]> typeInfo) {
 		super(format, typeInfo);
 	}
-	public static TFRecordInputFormat inputFormat = null;
 
 	@Override
 	public TypeInformation getProducedType() {
@@ -41,13 +40,12 @@ public class TFRecordSource extends InputFormatSourceFunction<byte[]> implements
 	}
 
 	public static TFRecordSource createSource(String[] paths, int epochs) {
-		inputFormat = new TFRecordInputFormat(paths, epochs);
+		TFRecordInputFormat inputFormat = new TFRecordInputFormat(paths, epochs);
 		return new TFRecordSource(inputFormat, TypeInformation.of(byte[].class));
 	}
 
-	public static void setHadoopConfiguration(Configuration configuration) {
-		if (null != inputFormat && null != configuration) {
-			inputFormat.setHadoopConfiguration(configuration);
-		}
+	public static TFRecordSource createSource(String[] paths, int epochs, Configuration configuration) {
+		TFRecordInputFormat inputFormat = new TFRecordInputFormat(paths, epochs, configuration);
+		return new TFRecordSource(inputFormat, TypeInformation.of(byte[].class));
 	}
 }

--- a/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordSource.java
+++ b/flink-ml-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/io/TFRecordSource.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * flink source: read tensorflow TFRecord format file, output TFRecord byte array.
@@ -32,6 +33,7 @@ public class TFRecordSource extends InputFormatSourceFunction<byte[]> implements
 	public TFRecordSource(InputFormat<byte[], ?> format, TypeInformation<byte[]> typeInfo) {
 		super(format, typeInfo);
 	}
+	public static TFRecordInputFormat inputFormat = null;
 
 	@Override
 	public TypeInformation getProducedType() {
@@ -39,7 +41,13 @@ public class TFRecordSource extends InputFormatSourceFunction<byte[]> implements
 	}
 
 	public static TFRecordSource createSource(String[] paths, int epochs) {
-		TFRecordInputFormat inputFormat = new TFRecordInputFormat(paths, epochs);
+		inputFormat = new TFRecordInputFormat(paths, epochs);
 		return new TFRecordSource(inputFormat, TypeInformation.of(byte[].class));
+	}
+
+	public static void setHadoopConfiguration(Configuration configuration) {
+		if (null != inputFormat && null != configuration) {
+			inputFormat.setHadoopConfiguration(configuration);
+		}
 	}
 }


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*(For example: This pull request makes user can stop workflow externally.)*


## Brief change log

*(for example:)*
  - *Send StopDagEvent to Airflow scheduler via notification service*
  - *Once received StopDagEvent, Airflow scheduler kills all running dag runs*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests.