### PR TITLE
Use java lib to unzip file

### DIFF
--- a/flink-ml-framework/src/main/java/org/flinkextended/flink/ml/util/FileUtil.java
+++ b/flink-ml-framework/src/main/java/org/flinkextended/flink/ml/util/FileUtil.java
@@ -27,8 +27,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 /**
  * down load zip file from remote file system to local
@@ -76,9 +80,7 @@ public class FileUtil {
 			fs.copyToLocalFile(remote, local);
 
 			LOG.info("Unzipping {} to {}", local.toString(), tempDirectory.toAbsolutePath().toString());
-			Preconditions.checkState(ShellExec.run(
-					String.format("unzip -q -d %s %s", tempDirectory.toAbsolutePath().toString(), local.toString()), LOG::info),
-					"Failed to unzip file:" + local.toString());
+			unzip(local.toString(), tempDirectory.toAbsolutePath().toString());
 
 			// dir name is the name of the zip file without extension by default
 			if (null == unzipDirName || unzipDirName.isEmpty()) {
@@ -99,5 +101,55 @@ public class FileUtil {
 		} finally {
 			FileUtils.deleteDirectory(tempDirectory.toFile());
 		}
+	}
+
+	public static void unzip(String zipFilePath, String destPath) throws IOException {
+		File destDir = new File(destPath);
+		byte[] buffer = new byte[1024];
+		ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFilePath));
+		ZipEntry zipEntry = zis.getNextEntry();
+		while (zipEntry != null) {
+			File newFile = newFile(destDir, zipEntry);
+			if (zipEntry.isDirectory()) {
+				if (!newFile.isDirectory() && !newFile.mkdirs()) {
+					throw new IOException("Failed to create directory " + newFile);
+				}
+			} else {
+				// fix for Windows-created archives
+				File parent = newFile.getParentFile();
+				if (!parent.isDirectory() && !parent.mkdirs()) {
+					throw new IOException("Failed to create directory " + parent);
+				}
+
+				extract_to_file(zis, newFile, buffer);
+			}
+			zipEntry = zis.getNextEntry();
+		}
+		zis.closeEntry();
+		zis.close();
+	}
+
+	private static void extract_to_file(ZipInputStream zis, File newFile,
+										byte[] buffer) throws IOException {
+		// write file content
+		FileOutputStream fos = new FileOutputStream(newFile);
+		int len;
+		while ((len = zis.read(buffer)) > 0) {
+			fos.write(buffer, 0, len);
+		}
+		fos.close();
+	}
+
+	private static File newFile(File destinationDir, ZipEntry zipEntry) throws IOException {
+		File destFile = new File(destinationDir, zipEntry.getName());
+
+		String destDirPath = destinationDir.getCanonicalPath();
+		String destFilePath = destFile.getCanonicalPath();
+
+		if (!destFilePath.startsWith(destDirPath + File.separator)) {
+			throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
+		}
+
+		return destFile;
 	}
 }

--- a/flink-ml-framework/src/main/java/org/flinkextended/flink/ml/util/PythonUtil.java
+++ b/flink-ml-framework/src/main/java/org/flinkextended/flink/ml/util/PythonUtil.java
@@ -132,9 +132,7 @@ public class PythonUtil {
 		LOG.info("local path:" + local.getName());
 		LOG.info("remote path:" + remote.getName());
 		fs.copyToLocalFile(remote, local);
-		Preconditions.checkState(ShellExec.run(
-				String.format("unzip -q -d %s %s", tmp.getPath(), local.toString()), LOG::info),
-				"Failed to unzip virtual env");
+		FileUtil.unzip(local.toString(), tmp.getPath());
 		String name = remote.getName();
 		int index = name.indexOf(".");
 		if (index != -1) {


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Use java lib to unzip files to avoid dependency on unzip command of the OS.

## Brief change log

Use java lib to unzip file


## Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.