### PR TITLE
Whitelist tensorflow dependency for auditwheel making manylinux wheel

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -70,3 +70,98 @@ jobs:
         with:
           name: ${{ matrix.package }}-wheels
           path: ./wheelhouse/*.whl
+  test-flink-ml-framework-wheel:
+    name: Test flink-ml-framework-wheel
+    needs: build-nightly-wheel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.6, 3.7, 3.8 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: flink-ml-framework-wheels
+          path: ./wheelhouse
+      - name: build
+        run: |
+          mvn -B install -pl flink-ml-framework -am -DskipTests
+      - name: test
+        env:
+          TF_ON_FLINK_IP: 127.0.0.1
+        run: |
+          pip install flink-ml-framework -f file://${PWD}/wheelhouse
+          mvn -B test -pl flink-ml-framework
+  test-flink-ml-tensorflow-wheel:
+    name: Test flink-ml-tensorflow-wheel
+    needs: build-nightly-wheel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.6, 3.7 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: flink-ml-tensorflow-wheels
+          path: ./wheelhouse
+      - name: build
+        run: |
+          mvn -B install -pl flink-ml-tensorflow -am -DskipTests
+      - name: test
+        env:
+          TF_ON_FLINK_IP: 127.0.0.1
+        run: |
+          pip install flink-ml-tensorflow -f file://${PWD}/wheelhouse
+          mvn -B test -pl flink-ml-tensorflow
+  test-flink-ml-tensorflow-2x-wheel:
+    name: Test flink-ml-tensorflow-2.x-wheel
+    needs: build-nightly-wheel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        python-version: [ 3.7, 3.8 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: flink-ml-tensorflow-2.x-wheels
+          path: ./wheelhouse
+      - name: build
+        run: |
+          mvn -B install -pl flink-ml-tensorflow-2.x -am -DskipTests
+      - name: test
+        env:
+          TF_ON_FLINK_IP: 127.0.0.1
+        run: |
+          pip install flink-ml-tensorflow-2.x -f file://${PWD}/wheelhouse
+          mvn -B test -pl flink-ml-tensorflow-2.x
+
+

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -45,101 +45,85 @@ jobs:
         with:
           name: flink-ml-dist
           path: flink-ml-dist/target/flink-ml-dist-*-bin
-  build-nightly-wheel:
-    name: Build ${{ matrix.package }} wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  build-linux-nightly-wheel:
+    name: Build python${{ matrix.python-version }} ${{ matrix.package }} wheels on ubuntu-20.04
+    runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
-        os: [ macOS-10.15, ubuntu-20.04 ]
+        python-version: [ 3.7, 3.8 ]
         package:
           - flink-ml-framework
           - flink-ml-tensorflow
           - flink-ml-tensorflow-2.x
+        exclude:
+          - package: flink-ml-tensorflow
+            python-version: 3.8
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - name: Build ${{ matrix.package }} wheels
-        uses: pypa/cibuildwheel@v2.3.1
+      - name: Build python${{ matrix.python-version }} ${{ matrix.package }} wheels
         env:
-          CIBW_ARCHS: "auto64"
-          CIBW_SKIP: "pp* *musllinux*"
-          CIBW_ENVIRONMENT: NIGHTLY_WHEEL=true
-        with:
-          package-dir: ${{ matrix.package }}/python
+          NIGHTLY_WHEEL: true
+        run: |
+          docker run -i --rm -v $PWD:/v -w /v -e 'NIGHTLY_WHEEL=true' --net=host quay.io/pypa/manylinux2010_x86_64 \
+            bash -c 'cd /v/${{ matrix.package }}/python \
+              && python${{ matrix.python-version }} setup.py bdist_wheel \
+              && for f in dist/*.whl; do echo repairing $f && bash -x -e /v/tools/auditwheel repair --plat manylinux2010_x86_64 -w /v/wheelhouse/ $f; done'
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.package }}-wheels
+          name: dl-on-flink-wheels
           path: ./wheelhouse/*.whl
-  test-flink-ml-framework-wheel:
-    name: Test flink-ml-framework-wheel
-    needs: build-nightly-wheel
-    runs-on: ${{ matrix.os }}
+  build-macos-nightly-wheel:
+    name: Build python${{ matrix.python-version }} ${{ matrix.package }} wheels on macOS-10.15
+    runs-on: macos-10.15
     strategy:
+      fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
-        python-version: [ 3.6, 3.7, 3.8 ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'adopt'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v2
-        with:
-          name: flink-ml-framework-wheels
-          path: ./wheelhouse
-      - name: build
-        run: |
-          mvn -B install -pl flink-ml-framework -am -DskipTests
-      - name: test
-        env:
-          TF_ON_FLINK_IP: 127.0.0.1
-        run: |
-          pip install flink-ml-framework -f file://${PWD}/wheelhouse
-          mvn -B test -pl flink-ml-framework
-  test-flink-ml-tensorflow-wheel:
-    name: Test flink-ml-tensorflow-wheel
-    needs: build-nightly-wheel
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
-        python-version: [ 3.6, 3.7 ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'adopt'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v2
-        with:
-          name: flink-ml-tensorflow-wheels
-          path: ./wheelhouse
-      - name: build
-        run: |
-          mvn -B install -pl flink-ml-tensorflow -am -DskipTests
-      - name: test
-        env:
-          TF_ON_FLINK_IP: 127.0.0.1
-        run: |
-          pip install flink-ml-tensorflow -f file://${PWD}/wheelhouse
-          mvn -B test -pl flink-ml-tensorflow
-  test-flink-ml-tensorflow-2x-wheel:
-    name: Test flink-ml-tensorflow-2.x-wheel
-    needs: build-nightly-wheel
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
         python-version: [ 3.7, 3.8 ]
+        package:
+          - flink-ml-framework
+          - flink-ml-tensorflow
+          - flink-ml-tensorflow-2.x
+        exclude:
+          - package: flink-ml-tensorflow
+            python-version: 3.8
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build python${{ matrix.python-version }} ${{ matrix.package }} wheels on macOS-10.15
+        env:
+          NIGHTLY_WHEEL: true
+        run: |
+          pip install wheel auditwheel
+          export ROOT_DIR=$PWD
+          mkdir $ROOT_DIR/wheelhouse
+          cd ${{ matrix.package }}/python
+          python setup.py bdist_wheel
+          cp dist/* $ROOT_DIR/wheelhouse
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dl-on-flink-wheels
+          path: ./wheelhouse/*.whl
+  test-wheel:
+    name: Test python${{ matrix.python-version }} ${{ matrix.package }} wheels on ${{ matrix.os }}
+    needs: [ build-linux-nightly-wheel, build-macos-nightly-wheel ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macOS-10.15, ubuntu-20.04 ]
+        python-version: [ 3.7, 3.8 ]
+        package:
+          - flink-ml-framework
+          - flink-ml-tensorflow
+          - flink-ml-tensorflow-2.x
+        exclude:
+          - package: flink-ml-tensorflow
+            python-version: 3.8
+          - package: flink-ml-tensorflow-2.x
+            python-version: 3.6
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8
@@ -152,16 +136,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/download-artifact@v2
         with:
-          name: flink-ml-tensorflow-2.x-wheels
+          name: dl-on-flink-wheels
           path: ./wheelhouse
       - name: build
         run: |
-          mvn -B install -pl flink-ml-tensorflow-2.x -am -DskipTests
+          mvn -B install -pl ${{ matrix.package }} -am -DskipTests
       - name: test
         env:
           TF_ON_FLINK_IP: 127.0.0.1
         run: |
-          pip install flink-ml-tensorflow-2.x -f file://${PWD}/wheelhouse
-          mvn -B test -pl flink-ml-tensorflow-2.x
-
-
+          ls $PWD/wheelhouse
+          pip install ${{ matrix.package }} -f file://${PWD}/wheelhouse
+          mvn -B test -pl ${{ matrix.package }}

--- a/tools/auditwheel
+++ b/tools/auditwheel
@@ -1,0 +1,27 @@
+#!/bin/bash
+##
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+##
+##   http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+##
+
+POLICY_JSON=$(find / -name manylinux-policy.json)
+
+sed -i "s/libresolv.so.2\"/libresolv.so.2\", \"libtensorflow_framework.so.1\", \"libtensorflow_framework.so.2\"/g" $POLICY_JSON
+
+cat $POLICY_JSON
+
+auditwheel $@


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Tensorflow has a known [issue](https://github.com/tensorflow/tensorflow/issues/31807) of loading a manylinux2010 repaired custom ops. We need to whitelist tensorflow dependency for auditwheel making manylinux wheel so that the custom ops can be loaded properly.


## Brief change log

- White list tensorflow dependency for auditwheel
- Test nightly build wheels in nightly workflow


## Verifying this change

Manually tested the github workflow.