### PR TITLE
Remove extra space of commands in quick start

### DIFF
--- a/doc/quick-start/quick_start_tensorflow_1.15.md
+++ b/doc/quick-start/quick_start_tensorflow_1.15.md
@@ -135,7 +135,7 @@ inference.
 ```sh
 
 ./bin/flink run \
-  -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \ 
+  -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
   --model-path "${MODEL_PATH}"
 
 ```

--- a/doc/quick-start/quick_start_tensorflow_2.3.md
+++ b/doc/quick-start/quick_start_tensorflow_2.3.md
@@ -135,7 +135,7 @@ inference.
 ```sh
 
 ./bin/flink run \
-  -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \ 
+  -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
   --model-path "${MODEL_PATH}"
 
 ```


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Remove extra space of commands in quick start

## Brief change log

Remove extra space of commands in quick start


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.