### PR TITLE
Use the archive url to download flink binary

### DIFF
--- a/doc/quick-start/quick_start_tensorflow_1.15.md
+++ b/doc/quick-start/quick_start_tensorflow_1.15.md
@@ -46,8 +46,8 @@ source venv/bin/activate
 Download a stable release of Flink 1.14, then extract the archive:
 
 ```sh
-curl -LO https://dlcdn.apache.org/flink/flink-1.14.3/flink-1.14.3-bin-scala_2.11.tgz
-tar -xzf flink-1.14.3-bin-scala_2.11.tgz
+curl -LO https://archive.apache.org/dist/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
+tar -xzf flink-1.14.4-bin-scala_2.11.tgz
 ```
 
 Please refer to [guide](https://nightlies.apache.org/flink/flink-docs-release-1.14//docs/try-flink/local_installation/) 
@@ -93,7 +93,7 @@ config the `taskmanager.numberOfTaskSlots` at `config/flink-config.yaml` to 2
 with the following command.
 
 ```sh
-cd flink-1.14.3
+cd flink-1.14.4
 sed -i.bak 's/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 2/' ./conf/flink-conf.yaml
 ```
 

--- a/doc/quick-start/quick_start_tensorflow_2.3.md
+++ b/doc/quick-start/quick_start_tensorflow_2.3.md
@@ -46,8 +46,8 @@ source venv/bin/activate
 Download a stable release of Flink 1.14, then extract the archive:
 
 ```sh
-curl -LO https://dlcdn.apache.org/flink/flink-1.14.3/flink-1.14.3-bin-scala_2.11.tgz
-tar -xzf flink-1.14.3-bin-scala_2.11.tgz
+curl -LO https://archive.apache.org/dist/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
+tar -xzf flink-1.14.4-bin-scala_2.11.tgz
 ```
 
 Please refer to [guide](https://nightlies.apache.org/flink/flink-docs-release-1.14//docs/try-flink/local_installation/) 
@@ -93,7 +93,7 @@ config the `taskmanager.numberOfTaskSlots` at `config/flink-config.yaml` to 2
 with the following command.
 
 ```sh
-cd flink-1.14.3
+cd flink-1.14.4
 sed -i.bak 's/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 2/' ./conf/flink-conf.yaml
 ```
 

--- a/tools/run_example.sh
+++ b/tools/run_example.sh
@@ -33,9 +33,9 @@ DL_ON_FLINK_BIN=$(realpath "${DL_ON_FLINK_BIN}")
 DL_ON_FLINK_WHEEL_DIR=$(realpath "${DL_ON_FLINK_WHEEL_DIR}")
 
 # Download Flink
-FLINK_BIN=flink-1.14.3-bin-scala_2.11.tgz
-[ -f ${FLINK_BIN} ] || curl -LO https://dlcdn.apache.org/flink/flink-1.14.3/flink-1.14.3-bin-scala_2.11.tgz
-tar -xzf flink-1.14.3-bin-scala_2.11.tgz
+FLINK_BIN=flink-1.14.4-bin-scala_2.11.tgz
+[ -f ${FLINK_BIN} ] || curl -LO https://archive.apache.org/dist/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
+tar -xzf flink-1.14.4-bin-scala_2.11.tgz
 
 # Un-tar DL on Flink
 tar -xzf "${DL_ON_FLINK_BIN}" --directory "${PWD}"
@@ -45,7 +45,7 @@ DL_ON_FLINK_DIR="${DL_ON_FLINK_DIR_ARRAY[0]}"
 pip install -f "${DL_ON_FLINK_WHEEL_DIR}" dl-on-flink-framework
 
 # Start flink cluster
-cd flink-1.14.3
+cd flink-1.14.4
 sed -i.bak 's/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 2/' ./conf/flink-conf.yaml
 rm ./conf/flink-conf.yaml.bak
 ./bin/start-cluster.sh


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Use the archive url to download flink binary to avoid breaking url.

## Brief change log

Use the archive url to download flink binary.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
