### PR TITLE
NodeUtils set python path properties with entry file path at first

### DIFF
--- a/dl-on-flink-framework/src/main/java/org/flinkextended/flink/ml/cluster/ClusterConfig.java
+++ b/dl-on-flink-framework/src/main/java/org/flinkextended/flink/ml/cluster/ClusterConfig.java
@@ -23,10 +23,12 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -103,6 +105,22 @@ public class ClusterConfig implements Serializable {
 
     public Set<String> getPythonFilePaths() {
         return pythonFilePaths;
+    }
+
+    /**
+     * Get a list of the python file paths where the first file paths is the entry files of the
+     * node.
+     */
+    public List<String> getPythonFilePathsList() {
+        List<String> res = new ArrayList<>();
+        res.add(entryPythonFilePath);
+        for (String pythonFilePath : pythonFilePaths) {
+            if (pythonFilePath.equals(entryPythonFilePath)) {
+                continue;
+            }
+            res.add(pythonFilePath);
+        }
+        return res;
     }
 
     public Integer getNodeCount(String nodeType) {

--- a/dl-on-flink-framework/src/test/java/org/flinkextended/flink/ml/cluster/ClusterConfigTest.java
+++ b/dl-on-flink-framework/src/test/java/org/flinkextended/flink/ml/cluster/ClusterConfigTest.java
@@ -20,6 +20,8 @@ package org.flinkextended.flink.ml.cluster;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
@@ -115,5 +117,18 @@ public class ClusterConfigTest {
         assertEquals("entry2.py", config2.getEntryPythonFilePath());
         assertEquals("main2", config2.getEntryFuncName());
         assertNull(config2.getPythonVirtualEnvZipPath());
+    }
+
+    @Test
+    public void testGetPythonFilePathsList() {
+        final ClusterConfig config =
+                ClusterConfig.newBuilder()
+                        .setProperty("k", "v")
+                        .addPythonFile("file1", "file2")
+                        .setNodeEntry("file3.py", "main")
+                        .build();
+        final List<String> pythonFilePathsList = config.getPythonFilePathsList();
+        assertEquals(3, pythonFilePathsList.size());
+        assertEquals("file3.py", pythonFilePathsList.get(0));
     }
 }

--- a/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/client/NodeUtils.java
+++ b/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/client/NodeUtils.java
@@ -46,7 +46,6 @@ import com.google.common.base.Joiner;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
 /**
  * NodeUtils provides methods to schedule node with various node type (e.g., worker, ps, chief) of a
@@ -73,7 +72,7 @@ public class NodeUtils {
         final StreamExecutionEnvironment env = tEnv.execEnv();
 
         final Builder<?> builder = clusterConfig.toBuilder();
-        registerFileToFlinkCache(env, clusterConfig.getPythonFilePaths(), builder);
+        registerFileToFlinkCache(env, clusterConfig.getPythonFilePathsList(), builder);
         ClusterConfig finalClusterConfig = builder.build();
 
         final SingleOutputStreamOperator<Void> nodeStream =
@@ -105,7 +104,7 @@ public class NodeUtils {
         final StreamExecutionEnvironment env = ((StreamTableEnvironmentImpl) tEnv).execEnv();
 
         final Builder<?> builder = clusterConfig.toBuilder();
-        registerFileToFlinkCache(env, clusterConfig.getPythonFilePaths(), builder);
+        registerFileToFlinkCache(env, clusterConfig.getPythonFilePathsList(), builder);
         ClusterConfig finalClusterConfig = builder.build();
 
         final SchemaResolver schemaResolver =
@@ -141,7 +140,7 @@ public class NodeUtils {
         final StreamExecutionEnvironment env = tEnv.execEnv();
 
         final Builder<?> builder = clusterConfig.toBuilder();
-        registerFileToFlinkCache(env, clusterConfig.getPythonFilePaths(), builder);
+        registerFileToFlinkCache(env, clusterConfig.getPythonFilePathsList(), builder);
         ClusterConfig finalClusterConfig = builder.build();
 
         final SingleOutputStreamOperator<Void> nodeStream =
@@ -174,7 +173,7 @@ public class NodeUtils {
         final StreamExecutionEnvironment env = tEnv.execEnv();
 
         final Builder<?> builder = clusterConfig.toBuilder();
-        registerFileToFlinkCache(env, clusterConfig.getPythonFilePaths(), builder);
+        registerFileToFlinkCache(env, clusterConfig.getPythonFilePathsList(), builder);
         ClusterConfig finalClusterConfig = builder.build();
 
         final SchemaResolver schemaResolver = tEnv.getCatalogManager().getSchemaResolver();
@@ -213,7 +212,7 @@ public class NodeUtils {
      * Register the file to Flink cache and set the properties to the given cluster config builder.
      */
     private static void registerFileToFlinkCache(
-            StreamExecutionEnvironment env, Set<String> filePaths, Builder<?> configBuilder) {
+            StreamExecutionEnvironment env, List<String> filePaths, Builder<?> configBuilder) {
         try {
             final List<String> pythonFiles =
                     PythonFileUtil.registerPythonLibFilesIfNotExist(


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

NodeUtils set python path properties with entry file path at first so that the node can pick up the right entry file from MLContext.


## Brief change log

- NodeUtils set python path properties with entry file path at first


## Verifying this change

This change added tests.