### PR TITLE
AMInputFormat wait for am node finish before return from reachedEnd

### DIFF
--- a/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/ops/inputformat/AMInputFormat.java
+++ b/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/ops/inputformat/AMInputFormat.java
@@ -29,6 +29,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /** The InputFormat that runs Application Master Node. */
 public class AMInputFormat extends AbstractNodeInputFormat<Void> {
@@ -70,6 +71,12 @@ public class AMInputFormat extends AbstractNodeInputFormat<Void> {
 
     @Override
     public boolean reachedEnd() throws IOException {
+        // block until node server finish and return true.
+        try {
+            waitServerFutureFinish();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new IOException(e);
+        }
         return true;
     }
 }

--- a/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/ops/inputformat/AbstractNodeInputFormat.java
+++ b/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/ops/inputformat/AbstractNodeInputFormat.java
@@ -168,18 +168,22 @@ public abstract class AbstractNodeInputFormat<OUT> extends RichInputFormat<OUT, 
 
     protected abstract Runnable getNodeServerRunnable(MLContext mlContext);
 
+    protected void waitServerFutureFinish() throws ExecutionException, InterruptedException {
+        serverFuture.get();
+    }
+
     @VisibleForTesting
     void preparePythonFiles() throws IOException {
         PythonFileUtil.preparePythonFilesForExec(getRuntimeContext(), mlContext);
     }
 
     @VisibleForTesting
-    void waitServerFutureFinish() throws ExecutionException, InterruptedException {
-        serverFuture.get();
+    boolean isClosed() {
+        return isClose.get();
     }
 
     @VisibleForTesting
-    boolean isClosed() {
-        return isClose.get();
+    FutureTask<Void> getServerFuture() {
+        return serverFuture;
     }
 }

--- a/dl-on-flink-operator/src/test/java/org/flinkextended/flink/ml/operator/ops/inputformat/AMInputFormatTest.java
+++ b/dl-on-flink-operator/src/test/java/org/flinkextended/flink/ml/operator/ops/inputformat/AMInputFormatTest.java
@@ -90,7 +90,24 @@ public class AMInputFormatTest {
     }
 
     @Test
-    public void testReachedEnd() throws IOException {
-        assertTrue(amInputFormat.reachedEnd());
+    public void testReachedEnd() throws IOException, InterruptedException {
+        amInputFormat.open(new NodeInputSplit(1, 0));
+
+        final Thread thread =
+                new Thread(
+                        () -> {
+                            try {
+                                assertTrue(amInputFormat.reachedEnd());
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                            }
+                        });
+
+        thread.start();
+
+        Thread.sleep(1000);
+        assertEquals(Thread.State.WAITING, thread.getState());
+        amInputFormat.getServerFuture().cancel(true);
+        thread.join();
     }
 }


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

AMInputFormat wait for am node finish before return from reachedEnd


## Brief change log

AMInputFormat wait for am node finish before return from reachedEnd

## Verifying this change

This change added tests.