### PR TITLE
Use RowCSVCoding as TF default encoding/decoding class

### DIFF
--- a/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/coding/RowCSVCoding.java
+++ b/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/coding/RowCSVCoding.java
@@ -33,12 +33,12 @@ import org.apache.flink.types.Row;
  */
 public class RowCSVCoding implements Coding<Row> {
     public static final String DELIM_CONFIG = MLConstants.SYS_PREFIX + "delim";
-    public static final String ENCODE_TYPES = MLConstants.SYS_PREFIX + "csv_encode_types";
-    public static final String DECODE_TYPES = MLConstants.SYS_PREFIX + "csv_decode_types";
+    public static final String ENCODE_TYPES = "input_types";
+    public static final String DECODE_TYPES = "output_types";
     public static final String TYPES_SPLIT_CONFIG = ",";
 
-    private DataTypes[] encodeTypes;
-    private DataTypes[] decodeTypes;
+    private final DataTypes[] encodeTypes;
+    private final DataTypes[] decodeTypes;
 
     private String delim;
 
@@ -65,7 +65,6 @@ public class RowCSVCoding implements Coding<Row> {
      *
      * @param bytes csv format record byte array.
      * @return table row object.
-     * @throws CodingException
      */
     @Override
     public Row decode(byte[] bytes) throws CodingException {
@@ -114,7 +113,6 @@ public class RowCSVCoding implements Coding<Row> {
      *
      * @param object table row object.
      * @return csv format record string.
-     * @throws CodingException
      */
     @Override
     public byte[] encode(Row object) throws CodingException {

--- a/dl-on-flink-tensorflow-2.x/python/example/tensorflow_on_flink_table.py
+++ b/dl-on-flink-tensorflow-2.x/python/example/tensorflow_on_flink_table.py
@@ -96,8 +96,8 @@ class TableExample:
         prop[MLCONSTANTS.ENCODING_CLASS] = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         prop[MLCONSTANTS.DECODING_CLASS] = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         inputSb = "INT_32" + "," + "INT_64" + "," + "FLOAT_32" + "," + "FLOAT_64" + "," + "STRING"
-        prop["sys:csv_encode_types"] = inputSb
-        prop["sys:csv_decode_types"] = inputSb
+        prop["input_types"] = inputSb
+        prop["output_types"] = inputSb
         prop[MLCONSTANTS.PYTHON_VERSION] = "3.7"
         source_file = os.getcwd() + "/../../src/test/resources/input.csv"
         sink_file = os.getcwd() + "/../../src/test/resources/output.csv"

--- a/dl-on-flink-tensorflow-2.x/python/tests/flink_ml_tensorflow/test_tf_cluster_config.py
+++ b/dl-on-flink-tensorflow-2.x/python/tests/flink_ml_tensorflow/test_tf_cluster_config.py
@@ -90,7 +90,11 @@ class TestTFClusterConfig(unittest.TestCase):
             "sys:record_reader_class": "org.flinkextended.flink.ml.tensorflow."
                                        "data.TFRecordReaderImpl",
             "sys:record_writer_class": "org.flinkextended.flink.ml.tensorflow."
-                                       "data.TFRecordWriterImpl"
+                                       "data.TFRecordWriterImpl",
+            "sys:decoding_class":
+                "org.flinkextended.flink.ml.operator.coding.RowCSVCoding",
+            "sys:encoding_class":
+                "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         }
 
         self.assertDictEqual({"worker": 2, "ps": 1},

--- a/dl-on-flink-tensorflow-2.x/python/tests/flink_ml_tensorflow/test_tf_utils.py
+++ b/dl-on-flink-tensorflow-2.x/python/tests/flink_ml_tensorflow/test_tf_utils.py
@@ -55,46 +55,39 @@ class TestTFUtils(unittest.TestCase):
         self.statement_set.execute().wait()
 
     def testIterationTrain(self):
-        coding_class = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         source_table = self.t_env.from_data_stream(
             self.env.from_collection([1, 2, 3, 4], Types.INT()))
         config = TFClusterConfig.new_builder() \
             .set_node_entry(os.path.join(get_resource_folder(),
                                          "print_input_iter.py"), "map_func") \
             .set_worker_count(1) \
-            .set_property(MLCONSTANTS.ENCODING_CLASS, coding_class) \
-            .set_property("sys:csv_encode_types", "INT_32") \
+            .set_property("input_types", "INT_32") \
             .build()
         train(self.statement_set, config, source_table, 4)
         self.statement_set.execute().wait()
 
     def testIterationTrainWithEarlyTermination(self):
-        coding_class = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         source_table = self.t_env.from_data_stream(
             self.env.from_collection([1, 2, 3, 4], Types.INT()))
         config = TFClusterConfig.new_builder() \
             .set_node_entry(os.path.join(get_resource_folder(),
                                          "print_input_iter.py"), "map_func") \
             .set_worker_count(1) \
-            .set_property(MLCONSTANTS.ENCODING_CLASS, coding_class) \
-            .set_property("sys:csv_encode_types", "INT_32") \
+            .set_property("input_types", "INT_32") \
             .build()
         train(self.statement_set, config, source_table, 1024)
         self.statement_set.execute().wait()
 
     def test_inference(self):
-        coding_class = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         config = TFClusterConfig.new_builder() \
             .set_worker_count(2) \
             .set_ps_count(1) \
             .set_node_entry(os.path.join(get_resource_folder(),
                                          "input_output.py"),
                             "map_func") \
-            .set_property(MLCONSTANTS.ENCODING_CLASS, coding_class) \
-            .set_property(MLCONSTANTS.DECODING_CLASS, coding_class) \
-            .set_property("sys:csv_encode_types",
+            .set_property("input_types",
                           "INT_32,INT_64,FLOAT_32,FLOAT_64,STRING") \
-            .set_property("sys:csv_decode_types",
+            .set_property("output_types",
                           "INT_32,INT_64,FLOAT_32,FLOAT_64,STRING") \
             .build()
 

--- a/dl-on-flink-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/client/TFClusterConfig.java
+++ b/dl-on-flink-tensorflow-common/src/main/java/org/flinkextended/flink/ml/tensorflow/client/TFClusterConfig.java
@@ -19,6 +19,7 @@
 package org.flinkextended.flink.ml.tensorflow.client;
 
 import org.flinkextended.flink.ml.cluster.ClusterConfig;
+import org.flinkextended.flink.ml.operator.coding.RowCSVCoding;
 import org.flinkextended.flink.ml.tensorflow.cluster.TFAMStateMachineImpl;
 import org.flinkextended.flink.ml.tensorflow.cluster.node.runner.TFMLRunner;
 import org.flinkextended.flink.ml.tensorflow.data.TFRecordReaderImpl;
@@ -80,6 +81,8 @@ public class TFClusterConfig extends ClusterConfig {
             setProperty(MLConstants.AM_STATE_MACHINE_CLASS, TFAMStateMachineImpl.class.getName());
             setProperty(MLConstants.RECORD_READER_CLASS, TFRecordReaderImpl.class.getName());
             setProperty(MLConstants.RECORD_WRITER_CLASS, TFRecordWriterImpl.class.getName());
+            setProperty(MLConstants.ENCODING_CLASS, RowCSVCoding.class.getName());
+            setProperty(MLConstants.DECODING_CLASS, RowCSVCoding.class.getName());
         }
 
         private Builder(TFClusterConfig tfClusterConfig) {

--- a/dl-on-flink-tensorflow/python/example/tensorflow_on_flink_table.py
+++ b/dl-on-flink-tensorflow/python/example/tensorflow_on_flink_table.py
@@ -96,8 +96,8 @@ class TableExample:
         prop[MLCONSTANTS.ENCODING_CLASS] = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         prop[MLCONSTANTS.DECODING_CLASS] = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         inputSb = "INT_32" + "," + "INT_64" + "," + "FLOAT_32" + "," + "FLOAT_64" + "," + "STRING"
-        prop["sys:csv_encode_types"] = inputSb
-        prop["sys:csv_decode_types"] = inputSb
+        prop["input_types"] = inputSb
+        prop["output_types"] = inputSb
         prop[MLCONSTANTS.PYTHON_VERSION] = "3.7"
         source_file = os.getcwd() + "/../../src/test/resources/input.csv"
         sink_file = os.getcwd() + "/../../src/test/resources/output.csv"

--- a/dl-on-flink-tensorflow/python/tests/flink_ml_tensorflow/test_flink_ml_api.py
+++ b/dl-on-flink-tensorflow/python/tests/flink_ml_tensorflow/test_flink_ml_api.py
@@ -64,7 +64,7 @@ class TestFlinkMlApi(unittest.TestCase):
         prop = {MLCONSTANTS.PYTHON_VERSION: '',
                 MLCONSTANTS.ENCODING_CLASS: 'org.flinkextended.flink.ml.operator.coding.RowCSVCoding',
                 MLCONSTANTS.DECODING_CLASS: 'org.flinkextended.flink.ml.operator.coding.RowCSVCoding',
-                'sys:csv_encode_types': 'STRING'}
+                'input_types': 'STRING'}
         tf_config = TFConfig(work_num, ps_num, prop, os.path.join(os.path.dirname(__file__), "add_one.py"),
                              "flink_stream_train", None)
         return tf_config

--- a/dl-on-flink-tensorflow/python/tests/flink_ml_tensorflow/test_tf_cluster_config.py
+++ b/dl-on-flink-tensorflow/python/tests/flink_ml_tensorflow/test_tf_cluster_config.py
@@ -90,7 +90,11 @@ class TestTFClusterConfig(unittest.TestCase):
             "sys:record_reader_class": "org.flinkextended.flink.ml.tensorflow."
                                        "data.TFRecordReaderImpl",
             "sys:record_writer_class": "org.flinkextended.flink.ml.tensorflow."
-                                       "data.TFRecordWriterImpl"
+                                       "data.TFRecordWriterImpl",
+            "sys:decoding_class":
+                "org.flinkextended.flink.ml.operator.coding.RowCSVCoding",
+            "sys:encoding_class":
+                "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         }
 
         self.assertDictEqual({"worker": 2, "ps": 1},

--- a/dl-on-flink-tensorflow/python/tests/flink_ml_tensorflow/test_tf_utils.py
+++ b/dl-on-flink-tensorflow/python/tests/flink_ml_tensorflow/test_tf_utils.py
@@ -55,46 +55,39 @@ class TestTFUtils(unittest.TestCase):
         self.statement_set.execute().wait()
 
     def testIterationTrain(self):
-        coding_class = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         source_table = self.t_env.from_data_stream(
             self.env.from_collection([1, 2, 3, 4], Types.INT()))
         config = TFClusterConfig.new_builder() \
             .set_node_entry(os.path.join(get_resource_folder(),
                                          "print_input_iter.py"), "map_func") \
             .set_worker_count(1) \
-            .set_property(MLCONSTANTS.ENCODING_CLASS, coding_class) \
-            .set_property("sys:csv_encode_types", "INT_32") \
+            .set_property("input_types", "INT_32") \
             .build()
         train(self.statement_set, config, source_table, 4)
         self.statement_set.execute().wait()
 
     def testIterationTrainWithEarlyTermination(self):
-        coding_class = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         source_table = self.t_env.from_data_stream(
             self.env.from_collection([1, 2, 3, 4], Types.INT()))
         config = TFClusterConfig.new_builder() \
             .set_node_entry(os.path.join(get_resource_folder(),
                                          "print_input_iter.py"), "map_func") \
             .set_worker_count(1) \
-            .set_property(MLCONSTANTS.ENCODING_CLASS, coding_class) \
-            .set_property("sys:csv_encode_types", "INT_32") \
+            .set_property("input_types", "INT_32") \
             .build()
         train(self.statement_set, config, source_table, 1024)
         self.statement_set.execute().wait()
 
     def test_inference(self):
-        coding_class = "org.flinkextended.flink.ml.operator.coding.RowCSVCoding"
         config = TFClusterConfig.new_builder() \
             .set_worker_count(2) \
             .set_ps_count(1) \
             .set_node_entry(os.path.join(get_resource_folder(),
                                          "input_output.py"),
                             "map_func") \
-            .set_property(MLCONSTANTS.ENCODING_CLASS, coding_class) \
-            .set_property(MLCONSTANTS.DECODING_CLASS, coding_class) \
-            .set_property("sys:csv_encode_types",
+            .set_property("input_types",
                           "INT_32,INT_64,FLOAT_32,FLOAT_64,STRING") \
-            .set_property("sys:csv_decode_types",
+            .set_property("output_types",
                           "INT_32,INT_64,FLOAT_32,FLOAT_64,STRING") \
             .build()
 

--- a/examples/tensorflow-on-flink/linear/flink_train.py
+++ b/examples/tensorflow-on-flink/linear/flink_train.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
             "org.flinkextended.flink.ml.operator.coding.RowCSVCoding",
         MLCONSTANTS.DECODING_CLASS:
             "org.flinkextended.flink.ml.operator.coding.RowCSVCoding",
-        'sys:csv_encode_types': 'STRING,STRING',
+        'input_types': 'STRING,STRING',
         'model_save_path': model_save_path,
         MLCONSTANTS.CONFIG_STORAGE_TYPE: MLCONSTANTS.STORAGE_LOCAL_FILE,
     }


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Use RowCSVCoding as TF default encoding/decoding class


## Brief change log
Use RowCSVCoding as TF default encoding/decoding class


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.