### PR TITLE
Update quick start examples

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -269,7 +269,7 @@ jobs:
           pip install --pre ${{ matrix.package }} -f file://${PWD}/wheelhouse
           mvn -B test -pl ${{ matrix.package }}
   run-example:
-    needs: [ build-and-upload-bin, build-linux-nightly-wheel, build-macos-nightly-wheel ]
+    needs: [ build-and-upload-bin, build-linux-nightly-wheel, build-macos-nightly-wheel, build-pytorch-nightly-wheel ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -300,6 +300,11 @@ jobs:
       - name: Run example on ${{ matrix.os }}
         run: |
           bash tools/run_example.sh dl-on-flink-*-bin.tgz wheelhouse
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: e2e-example-logs
+          path: ./flink-*/log
   deploy-snapshot:
     if: github.repository == 'flink-extended/dl-on-flink'
     needs: [ run-example, test-wheel ]

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -256,7 +256,7 @@ jobs:
           pip install ${{ matrix.package }} -f file://${PWD}/wheelhouse
           mvn -B test -pl ${{ matrix.package }}
   run-example:
-    needs: [ build-and-upload-bin, build-linux-wheel, build-macos-wheel ]
+    needs: [ build-and-upload-bin, build-linux-wheel, build-macos-wheel, build-pytorch-nightly-wheel ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -287,6 +287,11 @@ jobs:
       - name: Run example on ${{ matrix.os }}
         run: |
           bash tools/run_example.sh dl-on-flink-*-bin.tgz wheelhouse
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: e2e-example-logs
+          path: ./flink-*/log
   deploy-snapshot:
     if: github.repository == 'flink-extended/dl-on-flink'
     needs: [ run-example, test-wheel ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Deep Learning on Flink
 
 Deep Learning on Flink aims to integrate Flink and deep learning frameworks
-(e.g. TensorFlow, PyTorch, etc) to enable distributed deep learning training and
+(e.g. TensorFlow, PyTorch, etc.) to enable distributed deep learning training and
 inference on a Flink cluster.
 
 It runs the deep learning tasks inside a Flink operator so that Flink can help
@@ -18,13 +18,17 @@ Deep Learning on Flink is tested and supported on the following 64-bit systems:
 
 ## Support Framework Version
 - TensorFlow: 1.15.x & 2.4.x
+- PyTorch: 1.11.x
 - Flink: 1.14.x
  
 ## Getting Started
 
-You can follow [quick start tensorflow 1.15](doc/quick-start/quick_start_tensorflow_1.15.md)
-or [quick start tensorflow 2.4](doc/quick-start/quick_start_tensorflow_2.4.md) 
-to submit an example job to a local standalone Flink cluster.
+You can follow the following quick starts to submit an example job with 
+different deep learning frameworks to a local standalone Flink cluster.
+
+- [Quick Start Tensorflow 1.15](doc/quick-start/quick_start_tensorflow_1.15.md)
+- [Quick Start Tensorflow 2.4](doc/quick-start/quick_start_tensorflow_2.4.md)
+- [Quick Start PyTorch](doc/quick-start/quick_start_pytorch.md)
 
 ## Build From Source
 

--- a/doc/quick-start/quick_start_pytorch.md
+++ b/doc/quick-start/quick_start_pytorch.md
@@ -1,0 +1,148 @@
+<!--
+  Copyright 2022 Deep Learning on Flink Authors
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+# Quick Start
+
+This tutorial provides a quick introduction to using Deep Learning on Flink. 
+This guide will show you how to download and install the latest stable version 
+of Deep Learning on Flink. You will run a simple Flink job locally to train
+a linear model.
+
+## Environment Requirement
+
+- Java: 8
+- Python: 3.7 
+- Flink: 1.14
+- PyTorch: 1.10
+
+We strongly recommend using [virtualenv](https://virtualenv.pypa.io/en/latest/index.html) 
+or other similar tools for an isolated Python environment.
+
+```bash
+pip install virtualenv
+virtualenv venv --python=python3.7
+source venv/bin/activate
+```
+
+## Download & Install
+
+### Download Flink
+Download a stable release of Flink 1.14, then extract the archive:
+
+```sh
+curl -LO https://archive.apache.org/dist/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.11.tgz
+tar -xzf flink-1.14.4-bin-scala_2.11.tgz
+```
+
+Please refer to [guide](https://nightlies.apache.org/flink/flink-docs-release-1.14//docs/try-flink/local_installation/) 
+for more detailed step of downloading or installing Flink.
+
+### Download Deep Learning on Flink
+You can download the stable released binary release of Deep Learning on Flink,
+then extract the archive:
+
+```sh
+curl -LO https://github.com/flink-extended/dl-on-flink/releases/download/0.4.0/dl-on-flink-dist-0.4.0-bin.tgz
+tar -xzf dl-on-flink-dist-0.4.0-bin.tgz
+export DL_ON_FLINK_DIR="${PWD}"/./dl-on-flink-dist-0.4.0
+```
+
+Navigate to the extracted directory, you should see the following directory 
+layout:
+
+| Directory | Meaning |
+|---|---|
+|`lib/` | Directory containing the Deep Learning on Flink JARs compiled |
+|`examples/` | Directory containing examples. |
+
+### Install Python dependencies
+In order to run Deep Learning on Flink job, we need install the python
+dependency with pip.
+
+Install the latest stable release of `dl-on-flink-framwork`
+```bash
+python3 -m pip install --upgrade dl-on-flink-framework
+```
+
+Install the latest stable release of `dl-on-flink-pytorch`
+```bash
+python3 -m pip install --upgrade dl-on-flink-pytorch
+```
+
+## Starting Local Standalone Cluster
+
+In this example, we use two workers to train the model. Thus, there has to be
+at least 2 slots available in the Flink cluster. To do that, you should
+config the `taskmanager.numberOfTaskSlots` at `config/flink-config.yaml` to 2
+with the following command.
+
+```sh
+cd flink-1.14.4
+sed -i.bak 's/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 2/' ./conf/flink-conf.yaml
+```
+
+Usually, starting a local Flink cluster by running the following command is 
+enough for this quick start guide.
+
+```sh
+./bin/start-cluster.sh
+```
+
+You should be able to navigate to the web UI at 
+`http://localhost:8081` to view the Flink dashboard and see that 
+the cluster is up and running.
+
+## Model Train
+
+The examples are included in the binary release. You can run the following
+command to submit the Deep Learning on Flink job to train the linear model.
+
+```sh
+export MODEL_PATH="${PWD}"/./linear
+
+# Stream Training
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_train.py \
+  --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-pytorch-0.5.0-SNAPSHOT-jar-with-dependencies.jar \
+  --model-path "${MODEL_PATH}"
+  
+# Batch Training with 1280 samples for 100 epochs
+~/Downloads/flink-1.14.2/bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_train.py \
+  --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-pytorch-0.5.0-SNAPSHOT-jar-with-dependencies.jar \
+  --model-path "${MODEL_PATH}" \
+  --epoch 100 \
+  --sample-count 1280
+```
+
+After the job is submitted successfully, you should see the job at running state
+in the Flink web ui.
+
+If the job is finished, you will see the model saved at `$MODEL_PATH`.
+
+## Inference
+
+Now you can submit another Flink job to use the trained linear model to do
+inference.
+
+```sh
+
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_inference.py \
+  -pyfs "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/linear.py \
+  --model-path "${MODEL_PATH}"
+
+```

--- a/doc/quick-start/quick_start_tensorflow_1.15.md
+++ b/doc/quick-start/quick_start_tensorflow_1.15.md
@@ -113,10 +113,19 @@ command to submit the Deep Learning on Flink job to train the linear model.
 ```sh
 export MODEL_PATH="${PWD}"/./linear
 
+# Stream Training
 ./bin/flink run \
   -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
   --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-0.4.0-jar-with-dependencies.jar \
   --model-path "${MODEL_PATH}"
+  
+# Batch Training with 5120 samples for 100 epochs
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
+  --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-0.4.0-jar-with-dependencies.jar \
+  --model-path "${MODEL_PATH}" \
+  --epoch 100 \
+  --sample-count 5120
 ```
 
 After the job is submitted successfully, you should see the job at running state

--- a/doc/quick-start/quick_start_tensorflow_2.4.md
+++ b/doc/quick-start/quick_start_tensorflow_2.4.md
@@ -113,10 +113,19 @@ command to submit the Deep Learning on Flink job to train the linear model.
 ```sh
 export MODEL_PATH="${PWD}"/./linear
 
+# Stream Training
 ./bin/flink run \
   -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
   --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-2.x-0.4.0-jar-with-dependencies.jar \
   --model-path "${MODEL_PATH}"
+
+# Batch Training with 5120 samples for 100 epochs
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
+  --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-2.x-0.4.0-jar-with-dependencies.jar \
+  --model-path "${MODEL_PATH}" \
+  --epoch 100 \
+  --sample-count 5120
 ```
 
 After the job is submitted successfully, you should see the job at running state

--- a/examples/pytorch-on-flink/linear/flink_inference.py
+++ b/examples/pytorch-on-flink/linear/flink_inference.py
@@ -1,0 +1,94 @@
+#  Copyright 2022 Deep Learning on Flink Authors
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import argparse
+import logging
+import sys
+
+import torch
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import StreamTableEnvironment, \
+    FunctionContext, DataTypes
+from pyflink.table.udf import udf, ScalarFunction
+
+logger = logging.getLogger(__file__)
+
+
+class Predict(ScalarFunction):
+    """
+    The scalar function that do prediction with the given model.
+    """
+
+    def __init__(self, _model_path):
+        super().__init__()
+        self._model = None
+        self._model_path = _model_path
+
+    def open(self, function_context: FunctionContext):
+        self._model = torch.load(self._model_path)
+
+    def eval(self, x):
+        result = self._model(torch.tensor([x], dtype=torch.float64))
+        return result.item()
+
+
+def main():
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO,
+                        format="%(message)s")
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--model-path',
+        dest='model_path',
+        required=True,
+        help='Where the trained model should be saved')
+    parser.add_argument(
+        '--sample-count',
+        dest='sample_count',
+        required=False,
+        default=10,
+        help='Number of sample to inference. Default to 10'
+    )
+    argv = sys.argv[1:]
+    known_args, _ = parser.parse_known_args(argv)
+    model_path = known_args.model_path
+    sample_count = known_args.sample_count
+    logger.info("Inference with model at: {}".format(model_path))
+    # Prepare Flink environment
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1)
+    t_env = StreamTableEnvironment.create(env)
+
+    # Register the udf for prediction
+    t_env.create_temporary_function("predict",
+                                    udf(f=Predict(model_path),
+                                        result_type=DataTypes.DOUBLE()))
+    # Create the table of input for prediction
+    ddl = f"""
+            CREATE TABLE src (
+                x FLOAT
+            ) WITH (
+                'connector' = 'datagen',
+                'fields.x.min' = '0',
+                'fields.x.max' = '1',
+                'number-of-rows' = '{sample_count}',
+                'rows-per-second' = '1'
+            )
+        """
+    t_env.execute_sql(ddl)
+    table = t_env.sql_query("SELECT x, 2 * x + 1, predict(x) FROM src") \
+        .alias("x", "y", "predict")
+    table.execute().print()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/pytorch-on-flink/linear/flink_train.py
+++ b/examples/pytorch-on-flink/linear/flink_train.py
@@ -1,0 +1,105 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import argparse
+import logging
+import sys
+from datetime import datetime
+
+from dl_on_flink_pytorch.pytorch_cluster_config import PyTorchClusterConfig
+from dl_on_flink_pytorch.pytorch_utils import train
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import StreamTableEnvironment, TableDescriptor, Schema, \
+    DataTypes, expressions as expr
+from linear import train as train_entry
+
+logger = logging.getLogger(__file__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--model-path',
+        dest='model_path',
+        required=False,
+        default=f"/tmp/linear/{datetime.now().strftime('%Y%m%d%H%M')}",
+        help='Where the trained model should be saved')
+    parser.add_argument(
+        '--epoch',
+        dest='epoch',
+        required=False,
+        type=int,
+        default=1,
+        help='The number of epochs to train the model'
+    )
+    parser.add_argument(
+        '--sample-count',
+        dest='sample_count',
+        required=False,
+        type=int,
+        default=512000,
+        help='The number of samples for training per epoch'
+    )
+    argv = sys.argv[1:]
+    known_args, _ = parser.parse_known_args(argv)
+    return known_args
+
+
+def main():
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO,
+                        format="%(message)s")
+
+    known_args = parse_args()
+    model_save_path = known_args.model_path
+    epoch = known_args.epoch
+    sample_count = known_args.sample_count
+    logger.info(f"Model will be trained with {sample_count} samples for "
+                f"{epoch} epochs and saved at: {model_save_path}")
+
+    # Prepare Flink environment
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(2)
+    t_env = StreamTableEnvironment.create(env)
+    statement_set = t_env.create_statement_set()
+
+    # Create the table of samples for model training
+    schema = Schema.new_builder() \
+        .column('x', DataTypes.DOUBLE()) \
+        .column_by_expression('y', expr.call_sql("2 * x + 1")) \
+        .build()
+    input_tb = t_env.from_descriptor(TableDescriptor.for_connector("datagen")
+                                     .schema(schema)
+                                     .option('number-of-rows',
+                                             str(sample_count))
+                                     .option('fields.x.min', '0')
+                                     .option('fields.x.max', '1').build())
+
+    tf_cluster_config = PyTorchClusterConfig.new_builder() \
+        .set_node_entry(train_entry) \
+        .set_world_size(2) \
+        .set_property('input_types', 'STRING,STRING') \
+        .set_property('model_save_path', model_save_path) \
+        .set_property('storage_type', 'local_file') \
+        .build()
+
+    train(statement_set, tf_cluster_config, input_tb, epoch)
+
+    # Submit the job. Note that you should call execute method on the
+    # statement_set.
+    statement_set.execute().wait()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/pytorch-on-flink/linear/flink_train.py
+++ b/examples/pytorch-on-flink/linear/flink_train.py
@@ -1,10 +1,8 @@
-#  Licensed to the Apache Software Foundation (ASF) under one
-#  or more contributor license agreements.  See the NOTICE file
-#  distributed with this work for additional information
-#  regarding copyright ownership.  The ASF licenses this file
-#  to you under the Apache License, Version 2.0 (the
-#  "License"); you may not use this file except in compliance
-#  with the License.  You may obtain a copy of the License at
+#  Copyright 2022 Deep Learning on Flink Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -13,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 import argparse
 import logging
 import sys
@@ -23,6 +22,7 @@ from dl_on_flink_pytorch.pytorch_utils import train
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.table import StreamTableEnvironment, TableDescriptor, Schema, \
     DataTypes, expressions as expr
+
 from linear import train as train_entry
 
 logger = logging.getLogger(__file__)
@@ -49,7 +49,7 @@ def parse_args():
         dest='sample_count',
         required=False,
         type=int,
-        default=512000,
+        default=256000,
         help='The number of samples for training per epoch'
     )
     argv = sys.argv[1:]

--- a/examples/pytorch-on-flink/linear/linear.py
+++ b/examples/pytorch-on-flink/linear/linear.py
@@ -1,0 +1,32 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import torch
+from dl_on_flink_framework.context import Context
+from torch import nn
+
+
+class Linear(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(1, 1, dtype=torch.float32)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def train(context: Context):
+    pass

--- a/examples/tensorflow-on-flink/linear/linear.py
+++ b/examples/tensorflow-on-flink/linear/linear.py
@@ -25,7 +25,7 @@ import tensorflow as tf
 
 logger = logging.getLogger(__file__)
 
-logger.info("TensorFlow version:", tf.__version__)
+logger.info("TensorFlow version: %s", tf.__version__)
 is_tf2 = int(tf.__version__.split('.')[0]) == 2
 
 
@@ -128,6 +128,7 @@ def train(dataset_provider: Callable[[], tf.data.Dataset],
     config = json.loads(os.environ['TF_CONFIG'])
     is_chief = config['task']['type'] == 'worker' and \
         config['task']['index'] == 0
+    logger.info(f"is_chief: {is_chief}")
     callbacks: List[tf.keras.callbacks.Callback] = \
         [ModelSaveCallback(1000, model, model_save_path, is_chief)]
     if is_chief:
@@ -146,7 +147,7 @@ def stream_train(context):
 
     # Set the TF_CONFIG for distributed training
     tf_context = TFContext(context)
-    cluster = tf_context.to_tf_cluster(tf_context.properties["cluster"])
+    cluster = tf_context.get_tf_cluster_config()
     os.environ['TF_CONFIG'] = json.dumps({
         'cluster': cluster,
         'task': {'type': tf_context.get_node_type(),

--- a/examples/tensorflow-on-flink/linear/linear.py
+++ b/examples/tensorflow-on-flink/linear/linear.py
@@ -134,7 +134,7 @@ def train(dataset_provider: Callable[[], tf.data.Dataset],
     if is_chief:
         callbacks = callbacks + [StepLogCallback(100)]
 
-    model.fit(dataset_provider(), verbose=2, callbacks=callbacks)
+    model.fit(dataset_provider(), verbose=2, callbacks=callbacks, epochs=99999)
 
 
 def stream_train(context):

--- a/tools/run_example.sh
+++ b/tools/run_example.sh
@@ -104,4 +104,36 @@ MODEL_PATH="${PWD}"/./tf2/linear
 
 pip uninstall -y dl-on-flink-tensorflow-2.x
 
+# PyTorch linear example
+pip install --pre -f "${DL_ON_FLINK_WHEEL_DIR}" dl-on-flink-pytorch
+
+# Stream train
+MODEL_PATH="${PWD}"/./pytorch/linear
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_train.py \
+  --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-pytorch-*-jar-with-dependencies.jar \
+  --model-path "${MODEL_PATH}"
+[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_inference.py \
+  -pyfs "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/linear.py \
+  --model-path "${MODEL_PATH}"
+
+# Batch train iteratively
+~/Downloads/flink-1.14.2/bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_train.py \
+  --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-pytorch-*-jar-with-dependencies.jar \
+  --model-path "${MODEL_PATH}" \
+  --epoch 100 \
+  --sample-count 1280
+[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_inference.py \
+  -pyfs "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/linear.py \
+  --model-path "${MODEL_PATH}"
+
+pip uninstall -y dl-on-flink-pytorch
+
 ./bin/stop-cluster.sh

--- a/tools/run_example.sh
+++ b/tools/run_example.sh
@@ -51,6 +51,7 @@ rm ./conf/flink-conf.yaml.bak
 # Tensorflow 1.15 linear example
 pip install --pre -f "${DL_ON_FLINK_WHEEL_DIR}" dl-on-flink-tensorflow
 
+# Stream Train
 MODEL_PATH="${PWD}"/./tf1/linear
 ./bin/flink run \
   -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
@@ -61,16 +62,41 @@ MODEL_PATH="${PWD}"/./tf1/linear
 ./bin/flink run -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
   --model-path "${MODEL_PATH}"
 
+# Batch train iteratively
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
+  --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-*-jar-with-dependencies.jar \
+  --model-path "${MODEL_PATH}" \
+  --epoch 100 \
+  --sample-count 5120
+[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+
+./bin/flink run -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
+  --model-path "${MODEL_PATH}"
+
 pip uninstall -y dl-on-flink-tensorflow
 
 # Tensorflow 2.4 linear example
 pip install --pre -f "${DL_ON_FLINK_WHEEL_DIR}" dl-on-flink-tensorflow-2.x
 
+# Stream train
 MODEL_PATH="${PWD}"/./tf2/linear
 ./bin/flink run \
   -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
   --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-2.x-*-jar-with-dependencies.jar \
   --model-path "${MODEL_PATH}"
+[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+
+./bin/flink run -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
+  --model-path "${MODEL_PATH}"
+
+# Batch train iteratively
+./bin/flink run \
+  -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
+  --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-2.x-*-jar-with-dependencies.jar \
+  --model-path "${MODEL_PATH}" \
+  --epoch 100 \
+  --sample-count 5120
 [[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
 
 ./bin/flink run -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \

--- a/tools/run_example.sh
+++ b/tools/run_example.sh
@@ -57,7 +57,7 @@ MODEL_PATH="${PWD}"/./tf1/linear
   -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
   --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-*-jar-with-dependencies.jar \
   --model-path "${MODEL_PATH}"
-[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+[[ -d "${MODEL_PATH}" ]] || (echo "Model doesn't exist at ${MODEL_PATH}" && exit 1)
 
 ./bin/flink run -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
   --model-path "${MODEL_PATH}"
@@ -69,7 +69,7 @@ MODEL_PATH="${PWD}"/./tf1/linear
   --model-path "${MODEL_PATH}" \
   --epoch 100 \
   --sample-count 5120
-[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+[[ -d "${MODEL_PATH}" ]] || (echo "Model doesn't exist at ${MODEL_PATH}" && exit 1)
 
 ./bin/flink run -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
   --model-path "${MODEL_PATH}"
@@ -85,7 +85,7 @@ MODEL_PATH="${PWD}"/./tf2/linear
   -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_train.py \
   --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-tensorflow-2.x-*-jar-with-dependencies.jar \
   --model-path "${MODEL_PATH}"
-[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+[[ -d "${MODEL_PATH}" ]] || (echo "Model doesn't exist at ${MODEL_PATH}" && exit 1)
 
 ./bin/flink run -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
   --model-path "${MODEL_PATH}"
@@ -97,7 +97,7 @@ MODEL_PATH="${PWD}"/./tf2/linear
   --model-path "${MODEL_PATH}" \
   --epoch 100 \
   --sample-count 5120
-[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+[[ -d "${MODEL_PATH}" ]] || (echo "Model doesn't exist at ${MODEL_PATH}" && exit 1)
 
 ./bin/flink run -py "${DL_ON_FLINK_DIR}"/examples/tensorflow-on-flink/linear/flink_inference.py \
   --model-path "${MODEL_PATH}"
@@ -113,7 +113,7 @@ MODEL_PATH="${PWD}"/./pytorch/linear
   -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_train.py \
   --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-pytorch-*-jar-with-dependencies.jar \
   --model-path "${MODEL_PATH}"
-[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+[[ -f "${MODEL_PATH}" ]] || (echo "Model doesn't exist at ${MODEL_PATH}" && exit 1)
 
 ./bin/flink run \
   -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_inference.py \
@@ -121,13 +121,13 @@ MODEL_PATH="${PWD}"/./pytorch/linear
   --model-path "${MODEL_PATH}"
 
 # Batch train iteratively
-~/Downloads/flink-1.14.2/bin/flink run \
+./bin/flink run \
   -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_train.py \
   --jarfile "${DL_ON_FLINK_DIR}"/lib/dl-on-flink-pytorch-*-jar-with-dependencies.jar \
   --model-path "${MODEL_PATH}" \
   --epoch 100 \
   --sample-count 1280
-[[ -d "${MODEL_PATH}" ]] || echo "Model doesn't exist at ${MODEL_PATH}" || exit 1
+[[ -f "${MODEL_PATH}" ]] || (echo "Model doesn't exist at ${MODEL_PATH}" && exit 1)
 
 ./bin/flink run \
   -py "${DL_ON_FLINK_DIR}"/examples/pytorch-on-flink/linear/flink_inference.py \


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Update the quick start example for Tensorflow and Add a quick start example for PyTorch. Fix #728 


## Brief change log

- Update the quick start example for Tensorflow to use the new API
- Add option to run iterative training for Tensorflow quick start
- Add PyTorch quick start example


## Verifying this change

This change added tests.