### PR TITLE
Support adding extra cluster config properties to estimator

### DIFF
--- a/dl-on-flink-pytorch/python/tests/dl_on_flink_pytorch/flink_ml/test_pytorch_estimator.py
+++ b/dl-on-flink-pytorch/python/tests/dl_on_flink_pytorch/flink_ml/test_pytorch_estimator.py
@@ -44,8 +44,11 @@ class PrintModel(nn.Module):
         super(PrintModel, self).__init__()
         self.linear = nn.Linear(1, 1, dtype=torch.float64)
 
-    def forward(self, x1, x2, x3, x4):
-        print(x1, x2, x3, x4)
+    def forward(self, x1: torch.Tensor, x2, x3, x4):
+        assert x1.dtype == torch.int32, f"x1 should be type int32 but is {x1.dtype}"
+        assert x2.dtype == torch.int64, f"x2 should be type int64 but is {x2.dtype}"
+        assert x3.dtype == torch.float32, f"x3 should be type float32 but is {x3.dtype}"
+        assert x4.dtype == torch.float64, f"x4 should be type float64 but is {x4.dtype}"
         return self.linear(x4)
 
 

--- a/dl-on-flink-tensorflow-2.x/python/dl_on_flink_tensorflow/flink_ml/tf_estimator.py
+++ b/dl-on-flink-tensorflow-2.x/python/dl_on_flink_tensorflow/flink_ml/tf_estimator.py
@@ -62,7 +62,8 @@ class TFEstimator(Estimator):
                  feature_cols: List[str],
                  label_col: str,
                  max_epochs: int = 1,
-                 batch_size: Optional[int] = 32):
+                 batch_size: Optional[int] = 32,
+                 cluster_config_properties: Optional[Mapping[str, str]] = None):
         """
         A FlinkML Estimator implementation to distributed train a Tensorflow
         Keras Model with MultiWorkerMirroredStrategy.
@@ -81,6 +82,7 @@ class TFEstimator(Estimator):
         :param label_col: The name of the label_col.
         :param max_epochs: Maximum number of epoch to train the model.
         :param batch_size: The batch size default to 32.
+        :param cluster_config_properties: Extra cluster config properties.
         """
         self.max_epochs = max_epochs
         self.optimizer = optimizer
@@ -91,6 +93,8 @@ class TFEstimator(Estimator):
         self.feature_cols = feature_cols
         self.worker_num = worker_num
         self._statement_set = statement_set
+        self.cluster_config_properties = \
+            cluster_config_properties if cluster_config_properties is not None else {}
 
     def fit(self, *inputs: Table) -> 'TFModel':
         if len(inputs) != 1:
@@ -114,6 +118,9 @@ class TFEstimator(Estimator):
             .set_property(INPUT_TYPES,
                           self._get_input_type(input_table.get_schema())) \
             .set_property(MAX_EPOCHS, str(self.max_epochs))
+
+        for k, v in self.cluster_config_properties.items():
+            tf_cluster_config_builder.set_property(k, v)
 
         tf_model_factory = SimpleTFModelFactory(model=self.model,
                                                 loss=self.loss,


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Support adding extra cluster config properties to estimator.


## Brief change log

- Support adding extra cluster config properties to estimator.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.