### PR TITLE
Avoid tight loop in NodeOperator#onEpochWatermarkIncremented

### DIFF
--- a/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/ops/NodeOperator.java
+++ b/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/ops/NodeOperator.java
@@ -188,7 +188,10 @@ public class NodeOperator<OUT> extends AbstractStreamOperator<OUT>
             int epochWatermark, Context context, Collector<OUT> collector) throws Exception {
         mlContext.getOutputQueue().markBarrier();
         while (!serverFuture.isDone() && mlContext.getOutputQueue().canRead()) {
-            Thread.yield();
+            // We use sleep to avoid tight loop checking the python process consume
+            // all the data in the queue. The time of sleep is trivial compared to
+            // the time of training an epoch.
+            Thread.sleep(100);
         }
         if (serverFuture.isDone()) {
             LOG.info("{} finished at epoch {}", mlContext.getIdentity(), epochWatermark);


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

Avoid tight loop in NodeOperator#onEpochWatermarkIncremented


## Brief change log
Avoid tight loop in NodeOperator#onEpochWatermarkIncremented


## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *(please describe tests)*.