### PR TITLE
Fix unstable failover test

### DIFF
--- a/dl-on-flink-framework/src/main/java/org/flinkextended/flink/ml/cluster/rpc/NodeServer.java
+++ b/dl-on-flink-framework/src/main/java/org/flinkextended/flink/ml/cluster/rpc/NodeServer.java
@@ -41,6 +41,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.flinkextended.flink.ml.cluster.rpc.NodeServer.AMCommand.RESTART;
+import static org.flinkextended.flink.ml.cluster.rpc.NodeServer.AMCommand.STOP;
+
 /**
  * machine learning cluster node server. register to application master, make up machine learning
  * cluster.
@@ -265,11 +268,13 @@ public class NodeServer implements Runnable {
                 }
                 switch (getAmCommand()) {
                     case STOP:
+                        LOG.info("{} get command: {}", mlContext.getIdentity(), STOP);
                         stopMLRunner(runnerFuture);
                         setAmCommand(AMCommand.NOPE);
                         exit = true;
                         break;
                     case RESTART:
+                        LOG.info("{} get command: {}", mlContext.getIdentity(), RESTART);
                         stopMLRunner(runnerFuture);
                         runnerFuture = startMLRunner();
                         setAmCommand(AMCommand.NOPE);
@@ -277,7 +282,7 @@ public class NodeServer implements Runnable {
                 }
             }
         } catch (InterruptedException e) {
-            LOG.error(mlContext.getIdentity() + " node server interrupted");
+            LOG.error(mlContext.getIdentity() + " node server interrupted", e);
         } catch (Exception e) {
             LOG.error("Error to run node service {}.", e.getMessage());
             throw new RuntimeException(e);

--- a/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/ops/inputformat/AbstractNodeInputFormat.java
+++ b/dl-on-flink-operator/src/main/java/org/flinkextended/flink/ml/operator/ops/inputformat/AbstractNodeInputFormat.java
@@ -89,8 +89,7 @@ public abstract class AbstractNodeInputFormat<OUT> extends RichInputFormat<OUT, 
 
     @Override
     public boolean reachedEnd() throws IOException {
-        final boolean reachEnd = serverFuture.isDone();
-        return reachEnd;
+        return serverFuture.isDone();
     }
 
     @Override

--- a/dl-on-flink-operator/src/test/java/org/flinkextended/flink/ml/operator/ops/inputformat/AbstractNodeInputFormatTest.java
+++ b/dl-on-flink-operator/src/test/java/org/flinkextended/flink/ml/operator/ops/inputformat/AbstractNodeInputFormatTest.java
@@ -99,11 +99,14 @@ public class AbstractNodeInputFormatTest {
     }
 
     @Test
-    public void testNextRecord() throws IOException {
+    public void testNextRecord() throws IOException, ExecutionException, InterruptedException {
         nodeInputFormat.open(new NodeInputSplit(1, 0));
         assertFalse(nodeInputFormat.reachedEnd());
         assertEquals(Integer.valueOf(0), nodeInputFormat.nextRecord(null));
         assertEquals(Integer.valueOf(1), nodeInputFormat.nextRecord(null));
+        assertFalse(nodeInputFormat.reachedEnd());
+        nodeInputFormat.markFinish();
+        nodeInputFormat.waitServerFutureFinish();
         assertTrue(nodeInputFormat.reachedEnd());
     }
 

--- a/dl-on-flink-pytorch/src/test/java/org/flinkextended/flink/ml/pytorch/FailOverTest.java
+++ b/dl-on-flink-pytorch/src/test/java/org/flinkextended/flink/ml/pytorch/FailOverTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 Deep Learning on Flink Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flinkextended.flink.ml.pytorch;
+
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.client.JobCancellationException;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamStatementSet;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.flink.api.common.JobStatus.RUNNING;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Test for failover. */
+public class FailOverTest {
+
+    private StreamExecutionEnvironment env;
+    private StreamTableEnvironment tEnv;
+    private StreamStatementSet statementSet;
+    private final String alwaysFail = getScriptPathFromResources("always_fail.py");
+
+    @Before
+    public void setUp() {
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+        statementSet = tEnv.createStatementSet();
+    }
+
+    @Test
+    public void testCancelWhileFailover() throws InterruptedException, ExecutionException {
+        PyTorchClusterConfig config = buildTFConfig(alwaysFail);
+        PyTorchUtils.train(statementSet, config);
+
+        final JobClient jobClient = statementSet.execute().getJobClient().get();
+        while (jobClient.getJobStatus().get() != RUNNING) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(10_000);
+        jobClient.cancel().get();
+        while (jobClient.getJobStatus().get() == RUNNING) {
+            Thread.sleep(1000);
+        }
+
+        try {
+            jobClient.getJobExecutionResult().get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof JobCancellationException);
+        }
+    }
+
+    @Test
+    public void testTrainWithInputCancelWhileFailover()
+            throws InterruptedException, ExecutionException {
+        Table table = tEnv.fromDataStream(env.fromElements(1, 2, 3, 4));
+        PyTorchClusterConfig config = buildTFConfig(alwaysFail);
+        PyTorchUtils.train(statementSet, table, config);
+        //        statementSet.execute()
+
+        final JobClient jobClient = statementSet.execute().getJobClient().get();
+        while (jobClient.getJobStatus().get() != RUNNING) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(10_000);
+        jobClient.cancel().get();
+        while (jobClient.getJobStatus().get() == RUNNING) {
+            Thread.sleep(1000);
+        }
+
+        try {
+            jobClient.getJobExecutionResult().get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof JobCancellationException);
+        }
+    }
+
+    private PyTorchClusterConfig buildTFConfig(String pyFile) {
+        return PyTorchClusterConfig.newBuilder()
+                .setWorldSize(3)
+                .setNodeEntry(pyFile, "map_func")
+                .build();
+    }
+
+    private static String getScriptPathFromResources(String fileName) {
+        final URL resource = Thread.currentThread().getContextClassLoader().getResource(fileName);
+        assertNotNull(resource);
+        return resource.getPath();
+    }
+}

--- a/dl-on-flink-pytorch/src/test/resources/always_fail.py
+++ b/dl-on-flink-pytorch/src/test/resources/always_fail.py
@@ -1,0 +1,63 @@
+#  Copyright 2022 Deep Learning on Flink Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import time
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+def map_func(context):
+    key = context.identity
+    index = context.index
+    fail_num = context.get_current_attempt_index()
+    logger.info(key + " fail num: " + str(fail_num))
+    sys.stdout.flush()
+
+    if 1 == index:
+        time.sleep(1)
+        logger.info(key + " failover!")
+        raise Exception("fail over!")
+    else:
+        while True:
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    pass

--- a/dl-on-flink-tensorflow-2.x/src/test/java/org/flinkextended/flink/ml/tensorflow/client/RunWithFailTest.java
+++ b/dl-on-flink-tensorflow-2.x/src/test/java/org/flinkextended/flink/ml/tensorflow/client/RunWithFailTest.java
@@ -20,7 +20,10 @@ import org.flinkextended.flink.ml.tensorflow.storage.DummyStorage;
 import org.flinkextended.flink.ml.util.MLConstants;
 import org.flinkextended.flink.ml.util.SysUtil;
 
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.client.JobCancellationException;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamStatementSet;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
@@ -35,7 +38,9 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 
+import static org.apache.flink.api.common.JobStatus.RUNNING;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /** Failover unit test. */
 public class RunWithFailTest {
@@ -45,12 +50,16 @@ public class RunWithFailTest {
     private static final String simple_print = getScriptPathFromResources("simple_print.py");
     private static final String failover = getScriptPathFromResources("failover.py");
     private static final String failover2 = getScriptPathFromResources("failover2.py");
+    private static final String alwaysFail = getScriptPathFromResources("always_fail.py");
+
     private StreamStatementSet statementSet;
+    private StreamTableEnvironment tEnv;
+    private StreamExecutionEnvironment env;
 
     @Before
     public void setUp() throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
         statementSet = tEnv.createStatementSet();
     }
 
@@ -118,6 +127,55 @@ public class RunWithFailTest {
         expectedException.expect(ExecutionException.class);
         expectedException.expectMessage("Failed to wait job finish");
         statementSet.execute().await();
+    }
+
+    @Test
+    public void testCancelWhileFailover() throws InterruptedException, ExecutionException {
+        Table table = tEnv.fromDataStream(env.fromElements(1, 2, 3, 4));
+        TFClusterConfig config = buildTFConfig(alwaysFail);
+        TFUtils.train(statementSet, config);
+        //        statementSet.execute()
+
+        final JobClient jobClient = statementSet.execute().getJobClient().get();
+        while (jobClient.getJobStatus().get() != RUNNING) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(10_000);
+        jobClient.cancel().get();
+        while (jobClient.getJobStatus().get() == RUNNING) {
+            Thread.sleep(1000);
+        }
+
+        try {
+            jobClient.getJobExecutionResult().get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof JobCancellationException);
+        }
+    }
+
+    @Test
+    public void testTrainWithInputCancelWhileFailover()
+            throws InterruptedException, ExecutionException {
+        Table table = tEnv.fromDataStream(env.fromElements(1, 2, 3, 4));
+        TFClusterConfig config = buildTFConfig(alwaysFail);
+        TFUtils.train(statementSet, table, config);
+        //        statementSet.execute()
+
+        final JobClient jobClient = statementSet.execute().getJobClient().get();
+        while (jobClient.getJobStatus().get() != RUNNING) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(10_000);
+        jobClient.cancel().get();
+        while (jobClient.getJobStatus().get() == RUNNING) {
+            Thread.sleep(1000);
+        }
+
+        try {
+            jobClient.getJobExecutionResult().get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof JobCancellationException);
+        }
     }
 
     private static String getScriptPathFromResources(String fileName) {

--- a/dl-on-flink-tensorflow-2.x/src/test/resources/always_fail.py
+++ b/dl-on-flink-tensorflow-2.x/src/test/resources/always_fail.py
@@ -1,0 +1,63 @@
+#  Copyright 2022 Deep Learning on Flink Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import time
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+def map_func(context):
+    key = context.identity
+    index = context.index
+    fail_num = context.get_current_attempt_index()
+    logger.info(key + " fail num: " + str(fail_num))
+    sys.stdout.flush()
+
+    if 1 == index:
+        time.sleep(1)
+        logger.info(key + " failover!")
+        raise Exception("fail over!")
+    else:
+        while True:
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    pass

--- a/dl-on-flink-tensorflow/src/test/java/org/flinkextended/flink/ml/tensorflow/client/RunWithFailTest.java
+++ b/dl-on-flink-tensorflow/src/test/java/org/flinkextended/flink/ml/tensorflow/client/RunWithFailTest.java
@@ -20,7 +20,10 @@ import org.flinkextended.flink.ml.tensorflow.storage.DummyStorage;
 import org.flinkextended.flink.ml.util.MLConstants;
 import org.flinkextended.flink.ml.util.SysUtil;
 
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.client.JobCancellationException;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamStatementSet;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
@@ -35,7 +38,9 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 
+import static org.apache.flink.api.common.JobStatus.RUNNING;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /** Failover unit test. */
 public class RunWithFailTest {
@@ -45,12 +50,15 @@ public class RunWithFailTest {
     private static final String simple_print = getScriptPathFromResources("simple_print.py");
     private static final String failover = getScriptPathFromResources("failover.py");
     private static final String failover2 = getScriptPathFromResources("failover2.py");
+    private static final String alwaysFail = getScriptPathFromResources("always_fail.py");
     private StreamStatementSet statementSet;
+    private StreamExecutionEnvironment env;
+    private StreamTableEnvironment tEnv;
 
     @Before
     public void setUp() {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
         statementSet = tEnv.createStatementSet();
     }
 
@@ -118,6 +126,55 @@ public class RunWithFailTest {
         expectedException.expect(ExecutionException.class);
         expectedException.expectMessage("Failed to wait job finish");
         statementSet.execute().await();
+    }
+
+    @Test
+    public void testCancelWhileFailover() throws InterruptedException, ExecutionException {
+        Table table = tEnv.fromDataStream(env.fromElements(1, 2, 3, 4));
+        TFClusterConfig config = buildTFConfig(alwaysFail);
+        TFUtils.train(statementSet, config);
+        //        statementSet.execute()
+
+        final JobClient jobClient = statementSet.execute().getJobClient().get();
+        while (jobClient.getJobStatus().get() != RUNNING) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(10_000);
+        jobClient.cancel().get();
+        while (jobClient.getJobStatus().get() == RUNNING) {
+            Thread.sleep(1000);
+        }
+
+        try {
+            jobClient.getJobExecutionResult().get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof JobCancellationException);
+        }
+    }
+
+    @Test
+    public void testTrainWithInputCancelWhileFailover()
+            throws InterruptedException, ExecutionException {
+        Table table = tEnv.fromDataStream(env.fromElements(1, 2, 3, 4));
+        TFClusterConfig config = buildTFConfig(alwaysFail);
+        TFUtils.train(statementSet, table, config);
+        //        statementSet.execute()
+
+        final JobClient jobClient = statementSet.execute().getJobClient().get();
+        while (jobClient.getJobStatus().get() != RUNNING) {
+            Thread.sleep(1000);
+        }
+        Thread.sleep(10_000);
+        jobClient.cancel().get();
+        while (jobClient.getJobStatus().get() == RUNNING) {
+            Thread.sleep(1000);
+        }
+
+        try {
+            jobClient.getJobExecutionResult().get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof JobCancellationException);
+        }
     }
 
     private static String getScriptPathFromResources(String fileName) {

--- a/dl-on-flink-tensorflow/src/test/resources/always_fail.py
+++ b/dl-on-flink-tensorflow/src/test/resources/always_fail.py
@@ -1,0 +1,63 @@
+#  Copyright 2022 Deep Learning on Flink Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import time
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+def map_func(context):
+    key = context.identity
+    index = context.index
+    fail_num = context.get_current_attempt_index()
+    logger.info(key + " fail num: " + str(fail_num))
+    sys.stdout.flush()
+
+    if 1 == index:
+        time.sleep(1)
+        logger.info(key + " failover!")
+        raise Exception("fail over!")
+    else:
+        while True:
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

The `AbstractNodeInputFormat` is closed when the node server failover, which is not intended. We update the `AbstractNodeInputFormat` so that it only close when the node server finishes.


## Brief change log

Fix unstable failover test


## Verifying this change

This change added tests.